### PR TITLE
Remove KV cache from T5

### DIFF
--- a/flue-core/src/flux/mod.rs
+++ b/flue-core/src/flux/mod.rs
@@ -30,7 +30,7 @@ pub struct FluxModel {
 }
 
 impl ModelLike for FluxModel {
-    fn run(&mut self, request: GenerationRequest) -> anyhow::Result<DynamicImage> {
+    fn run(&self, request: GenerationRequest) -> anyhow::Result<DynamicImage> {
         // Set defaults.
         let width = request.width.unwrap_or(1360);
         let height = request.height.unwrap_or(768);

--- a/flue-core/src/lib.rs
+++ b/flue-core/src/lib.rs
@@ -26,5 +26,5 @@ pub struct GenerationRequest {
 }
 
 pub trait ModelLike: Send + Sync {
-    fn run(&mut self, request: GenerationRequest) -> anyhow::Result<DynamicImage>;
+    fn run(&self, request: GenerationRequest) -> anyhow::Result<DynamicImage>;
 }

--- a/flue-server/src/main.rs
+++ b/flue-server/src/main.rs
@@ -12,10 +12,7 @@ use flue_core::{DeviceMap, FluxLoader, GenerationRequest, Loader, ModelLike};
 use hf_hub::api::tokio::Api;
 use image::DynamicImage;
 use serde::Serialize;
-use std::{
-    io::Cursor,
-    sync::{Arc, Mutex},
-};
+use std::{io::Cursor, sync::Arc};
 use tokio::{self, net::TcpListener};
 
 // Define command line arguments
@@ -54,7 +51,7 @@ struct GenerationResponse {
 
 // Application state containing the preloaded models and device settings.
 #[derive(Clone)]
-struct AppState(Arc<Mutex<dyn ModelLike>>);
+struct AppState(Arc<dyn ModelLike>);
 
 async fn generate_image_handler(
     State(state): State<Arc<AppState>>,
@@ -71,7 +68,7 @@ async fn generate_image_handler(
 
 /// This function uses the preloaded models from `state` to generate an image (base64).
 async fn generate_image(params: GenerationRequest, state: &AppState) -> Result<String> {
-    let image = state.0.lock().unwrap().run(params)?;
+    let image = state.0.run(params)?;
     image_to_base64_png(&image)
 }
 
@@ -82,7 +79,7 @@ async fn main() -> Result<()> {
     let model = FluxLoader::load(Api::new()?, DeviceMap::default()).await?;
 
     // Build application state and wrap in Arc.
-    let app_state = AppState(Arc::new(Mutex::new(model)));
+    let app_state = AppState(Arc::new(model));
     let shared_state = Arc::new(app_state);
 
     // --- Build axum router with shared state ---


### PR DESCRIPTION
- This is probably bad anyway
- Also we can get rid of &mut self in the forward pass, simplifying concurrency implementations -> Cleaner server