### PR TITLE
Improve typos configuration

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,10 +1,11 @@
-[default]
-extend-ignore-identifiers-re = [
-    "mmaped",
-    "Nd",
-    "arange",
-    "nin",
-]
-
 [files]
-extend-exclude = []
+extend-exclude = [
+    ".git/",
+]
+ignore-hidden = false
+
+[type.rust.extend-identifiers]
+arange = "arange"
+EmbedNd = "EmbedNd"
+from_mmaped_safetensors = "from_mmaped_safetensors"
+nin_shortcut = "nin_shortcut"


### PR DESCRIPTION
- scan dot files
- narrow down ignores: Rust only, complete variable names
